### PR TITLE
Script to clone issues + base configuration change

### DIFF
--- a/org-cyf-itp/content/data-flows/project/prep/index.md
+++ b/org-cyf-itp/content/data-flows/project/prep/index.md
@@ -7,8 +7,8 @@ emoji= '🧑🏿‍💻'
 weight = 1
 [[blocks]]
 name="Planning and organising your project"
-src="https://raw.githubusercontent.com/Migracode-Barcelona/Project-TV-Show/main/readme.md"
+src="https://github.com/Migracode-Barcelona/Project-TV-Show/readme"
 [[blocks]]
 name="Setting up"
-src="https://raw.githubusercontent.com/Migracode-Barcelona/Project-TV-Show/main/levels/level-0.md"
+src="https://github.com/Migracode-Barcelona/Project-TV-Show/issues/7"
 +++

--- a/org-cyf-itp/content/data-flows/project/prep/index.md
+++ b/org-cyf-itp/content/data-flows/project/prep/index.md
@@ -7,7 +7,7 @@ emoji= '🧑🏿‍💻'
 weight = 1
 [[blocks]]
 name="Planning and organising your project"
-src="https://github.com/Migracode-Barcelona/Project-TV-Show/readme"
+src="https://github.com/Migracode-Barcelona/Project-TV-Show/blob/main/readme.md"
 [[blocks]]
 name="Setting up"
 src="https://github.com/Migracode-Barcelona/Project-TV-Show/issues/7"

--- a/org-cyf-itp/content/data-flows/project/prep/index.md
+++ b/org-cyf-itp/content/data-flows/project/prep/index.md
@@ -7,7 +7,7 @@ emoji= '🧑🏿‍💻'
 weight = 1
 [[blocks]]
 name="Planning and organising your project"
-src="https://github.com/Migracode-Barcelona/Project-TV-Show/blob/main/readme.md"
+src="https://github.com/Migracode-Barcelona/Project-TV-Show/readme"
 [[blocks]]
 name="Setting up"
 src="https://github.com/Migracode-Barcelona/Project-TV-Show/issues/7"

--- a/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
@@ -6,7 +6,7 @@ menu_level = ['sprint']
 weight = 3
 [[blocks]]
 name="Energiser"
-src="blocks/energiser
+src="blocks/energiser"
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"

--- a/org-cyf-itp/content/onboarding/sprints/1/prep/index.md
+++ b/org-cyf-itp/content/onboarding/sprints/1/prep/index.md
@@ -31,9 +31,9 @@ time=15
 name="Set up Planner"
 src="https://github.com/CodeYourFuture/Coursework-Planner/tree/main"
 time=30
-[[blocks]]
+<!-- [[blocks]]
 name="CYF Blog"
-src="module/induction/cyf-blog"
+src="module/induction/cyf-blog" -->
 [[blocks]]
 name="Development Process"
 src="module/induction/development-process"

--- a/org-cyf-theme/hugo.toml
+++ b/org-cyf-theme/hugo.toml
@@ -7,9 +7,9 @@ baseURL = "https://curriculum.codeyourfuture.io/"
 [module]
 # MODULE MOUNTS this is how we inherit the layout code and shared content
   [[module.imports]]
-    path = "github.com/CodeYourFuture/curriculum/common-theme" 
+    path = "github.com/CodeYourFuture/curriculum/common-theme"
   [[module.imports]]
-    path = "github.com/CodeYourFuture/curriculum/common-content" 
+    path = "github.com/CodeYourFuture/curriculum/common-content"
     [[module.imports.mounts]]
       source = "en"
       target = "content"
@@ -19,7 +19,7 @@ baseURL = "https://curriculum.codeyourfuture.io/"
 # Taxonomies common to CYF sites
   activity = 'activities'
 
-# Default menus     
+# Default menus
 [menus]
      [[menus.secondary]]
         name = "👋🏿 About MigraCode"
@@ -40,17 +40,17 @@ description = "A free and open source software development programme."
 main_website = "https://codeyourfuture.io/"
 main_org_name = "Code Your Future"
 our_name="CYF"
-owner = "CodeYourFuture"
-org = "https://github.com/CodeYourFuture"
-repo = "https://github.com/CodeYourFuture/curriculum/"
+owner = "Migracode-Barcelona"
+org = "https://github.com/Migracode-Barcelona"
+repo = "https://github.com/Migracode-Barcelona/curriculum2.0/"
 pdrepo = "CYF-PD"
-root = "curriculum"
+root = "curriculum2.0"
 googleFonts="https://fonts.googleapis.com/css2?family=Jura:wght@400;600;700&family=Inter:wght@400;500;700&family=Noto+Color+Emoji&family=Raleway:wght@300;600;800;900&family=Lato:wght@500;800&display=swap"
 
 # We use a proxy which concatenates paginated responses, otherwise we miss results.
 # Daniel is currently hosting this code https://github.com/illicitonion/github-issue-proxy but we should work out a long-term maintainable solution to this problem.
 # The /cached/120 path prefix here caches results for 2 hours to avoid rate limits. Drop the /cached/120 if you need fresh results.
-orgapi = "https://github-issue-proxy.illicitonion.com/cached/120/repos/CodeYourFuture/"
+orgapi = "https://github-issue-proxy.illicitonion.com/cached/120/repos/Migracode-Barcelona/"
 
 [caches.getresource]
 # Disable caching of fetches - we want every build to get up to date content for issues, so that if people make clarifications or fixes to issues, we pick them up.

--- a/org-cyf-theme/hugo.toml
+++ b/org-cyf-theme/hugo.toml
@@ -44,7 +44,7 @@ owner = "Migracode-Barcelona"
 org = "https://github.com/Migracode-Barcelona"
 repo = "https://github.com/Migracode-Barcelona/curriculum2.0/"
 pdrepo = "CYF-PD"
-root = "curriculum"
+root = "curriculum2.0"
 googleFonts="https://fonts.googleapis.com/css2?family=Jura:wght@400;600;700&family=Inter:wght@400;500;700&family=Noto+Color+Emoji&family=Raleway:wght@300;600;800;900&family=Lato:wght@500;800&display=swap"
 
 # We use a proxy which concatenates paginated responses, otherwise we miss results.

--- a/org-cyf-theme/hugo.toml
+++ b/org-cyf-theme/hugo.toml
@@ -44,7 +44,7 @@ owner = "Migracode-Barcelona"
 org = "https://github.com/Migracode-Barcelona"
 repo = "https://github.com/Migracode-Barcelona/curriculum2.0/"
 pdrepo = "CYF-PD"
-root = "curriculum2.0"
+root = "curriculum"
 googleFonts="https://fonts.googleapis.com/css2?family=Jura:wght@400;600;700&family=Inter:wght@400;500;700&family=Noto+Color+Emoji&family=Raleway:wght@300;600;800;900&family=Lato:wght@500;800&display=swap"
 
 # We use a proxy which concatenates paginated responses, otherwise we miss results.

--- a/tooling/python/issue_bulk_clone.py
+++ b/tooling/python/issue_bulk_clone.py
@@ -1,0 +1,140 @@
+import os
+import requests
+import json
+import argparse
+
+##
+# How to run the script:
+#
+# > export GITHUB_TOKEN="<your github secret token>"
+# > python issue_bulk_clone.py <source repo> <destination repo>
+#
+# Example:
+# > python issue_bulk_clone.py CodeYourFuture/Module-Data-Flows Migracode-Barcelona/Module-Data-Flows
+#
+# Note: your token must have read access to issues and labels in the source repo, and *write access* for the same in the destination one.
+# At the time of writing, a personal fine-grained access token with r/w access on the destination repo over issues, pull requests and discussions sufficed.
+#
+# Note: if cloning issues to recently created repo, remember to enable the "Issues" feature in the UI (Settings > Features > [] Issues).
+# Otherwise the script will get a 410 error when attempting to list issues within the destination repo.
+
+# Modules
+# https://github.com/CodeYourFuture/The-Piscine
+# https://github.com/CodeYourFuture/Module-Onboarding
+# https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data
+# https://github.com/CodeYourFuture/Module-Data-Groups
+# https://github.com/CodeYourFuture/Module-Data-Flows
+
+
+# Read GitHub token from environment variable
+GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
+if not GITHUB_TOKEN:
+    raise ValueError("GitHub token not found in environment variables")
+
+# Helper functions
+def get_all_issues(repo):
+    """Fetch all issues from the given repository, handling pagination."""
+    issues = []
+    page = 1
+    while True:
+        url = f'https://api.github.com/repos/{repo}/issues?page={page}&per_page=100'
+        headers = {'Authorization': f'token {GITHUB_TOKEN}'}
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+        if not data:
+            break
+        issues.extend(data)
+        page += 1
+    return issues
+
+def get_labels(repo):
+    """Fetch all labels from the given repository."""
+    labels = {}
+    page = 1
+    while True:
+        url = f'https://api.github.com/repos/{repo}/labels?page={page}&per_page=100'
+        headers = {'Authorization': f'token {GITHUB_TOKEN}'}
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+        if not data:
+            break
+        for label in data:
+            labels[label['name']] = label['color']
+        page += 1
+    return labels
+
+def create_label(repo, label_name, color):
+    """Create a label in the target repository."""
+    url = f'https://api.github.com/repos/{repo}/labels'
+    headers = {
+        'Authorization': f'token {GITHUB_TOKEN}',
+        'Content-Type': 'application/json'
+    }
+    label_data = {'name': label_name, 'color': color}
+    response = requests.post(url, headers=headers, data=json.dumps(label_data))
+    if response.status_code == 422:  # Label already exists
+        print(f"Label '{label_name}' already exists in target repo.")
+    else:
+        response.raise_for_status()
+        print(f"Created label: {label_name}")
+
+def create_issue(repo, title, body, labels):
+    """Create an issue in the target repository."""
+    url = f'https://api.github.com/repos/{repo}/issues'
+    headers = {'Authorization': f'token {GITHUB_TOKEN}'}
+    issue_data = {'title': title, 'body': body, 'labels': labels}
+    response = requests.post(url, headers=headers, data=json.dumps(issue_data))
+    response.raise_for_status()
+    return response.json()
+
+def clone_issues(source_repo, target_repo):
+    """Clone issues from source_repo to target_repo, copying all labels along with colors."""
+    source_labels = get_labels(source_repo)
+    target_labels = get_labels(target_repo)
+
+    # Create labels in the target repo if they don't exist
+    for label_name, color in source_labels.items():
+        if label_name not in target_labels:
+            create_label(target_repo, label_name, color)
+
+    issues = get_all_issues(source_repo)
+    for issue in issues:
+        if "pull_request" not in issue:  # Skip pull requests, only clone issues
+            title = issue['title']
+            body = issue['body'] or ''
+            labels = [label['name'] for label in issue.get('labels', [])]
+            print(f'Cloning issue: {title} with labels {labels}')
+            created_issue = create_issue(target_repo, title, body, labels)
+            print(f'Created: {created_issue["html_url"]}')
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description='Script to copy issues from one github repository to another. Repos must be expressed as <owner>/<repo name>.'
+    )
+    parser.add_argument(
+        'source_repo',
+        type=str,
+        help='The source github repository.'
+    )
+    parser.add_argument(
+        'destination_repo',
+        type=str,
+        help='The destination github repository.'
+    )
+
+    args = parser.parse_args()
+
+    return args.source_repo, args.destination_repo
+
+def main():
+    source_repo, destination_repo = parse_arguments()
+
+    print(f"Copying issues from {source_repo} to {destination_repo}...")
+
+    # Run the cloning process
+    clone_issues(source_repo, destination_repo)
+
+if __name__ == "__main__":
+    main()

--- a/tooling/python/issue_bulk_clone.py
+++ b/tooling/python/issue_bulk_clone.py
@@ -24,6 +24,8 @@ import argparse
 # https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data
 # https://github.com/CodeYourFuture/Module-Data-Groups
 # https://github.com/CodeYourFuture/Module-Data-Flows
+# https://github.com/CodeYourFuture/Project-TV-Show
+
 
 
 # Read GitHub token from environment variable


### PR DESCRIPTION
1. Changed the base configuration to point to the `Migracode-Barcelona` owner
2. Added a python script that clones issues with their labels between github repos

The following repos have been cloned (forked) and their issues copied over with the tool in this PR:
- https://github.com/CodeYourFuture/The-Piscine -
-  https://github.com/CodeYourFuture/Module-Onboarding
- https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data
- https://github.com/CodeYourFuture/Module-Data-Groups
- https://github.com/CodeYourFuture/Module-Data-Flows
- https://github.com/CodeYourFuture/Project-TV-Show (was forked already, only copied issues)

Hey @BlacHera, I've fixed a couple of things introduced in #134 that were breaking the build:
- [here](https://github.com/Migracode-Barcelona/curriculum2.0/pull/133/files#diff-861f981d4affbf5b503d842c2a9bc2d796c87de16ef3306c4e59319a562502cbL10-R13), the build was complaining with the following errors ([build log](https://app.netlify.com/projects/migracode-itp/deploys/6886578a933cfc00089479ef#L88)):

  ```
  6:45:41 PM: ERROR Couldn't find readme at https://raw.githubusercontent.com/Migracode-Barcelona/Project-TV-Show/main/readme.md/readme
  ERROR Couldn't find anything at https://raw.githubusercontent.com/Migracode-Barcelona/Project-TV-Show/main/readme.md/readme
  ERROR Couldn't find readme at https://raw.githubusercontent.com/Migracode-Barcelona/Project-TV-Show/main/levels/level-0.md/readme
  ERROR Couldn't find anything at https://raw.githubusercontent.com/Migracode-Barcelona/Project-TV-Show/main/levels/level-0.md/readme
  WARN  Unable to get remote resource "https://raw.githubusercontent.com/user-attachments/assets/cec30254-506b-4786-8295-3c145c69472a"
  ```

  In this case I've taken the issues on `Project-TV-Show` over to MC's fork, and pointed to the same issue as in CYF ([original](https://github.com/CodeYourFuture/Project-TV-Show/issues/4) and [copy](https://github.com/Migracode-Barcelona/Project-TV-Show/issues/7))
  

- [here](https://github.com/Migracode-Barcelona/curriculum2.0/pull/133/files#diff-7c26963dd01e250081b3ebb034753d038ed8c0280567cd8d6c4a43ffa6e244bbR9), a typo. This was manifested in the build as follows ([build log](https://app.netlify.com/projects/migracode-itp/deploys/688654c90eea5a0008209f35#L89)):

  ```
  6:33:31 PM: Error: error building site: process: readAndProcessContent: "/opt/build/repo/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md:9:22": unmarshal failed: toml: basic strings cannot have new lines
  ```