### PR TITLE
Day plan changes and Submission links

### DIFF
--- a/common-content/en/blocks/disclaimer-mc/index.md
+++ b/common-content/en/blocks/disclaimer-mc/index.md
@@ -1,6 +1,7 @@
 +++
 title="Disclaimer"
 emoji="⚠️"
+time = 0
  [build]
    render = 'never'
    list = 'local'

--- a/org-cyf-itp/content/data-flows/success/index.md
+++ b/org-cyf-itp/content/data-flows/success/index.md
@@ -45,4 +45,4 @@ However, please do not make any pull requests to the original Code Your Future r
 
 ## ✅ To complete _this_ module, you must:
 
-Submit all the following items to complete this module on your private slack channel with the MigraCode team.
+Submit all the following items to complete this module through this [Submission Form](https://airtable.com/appHB49eVBBLG0KZH/pagHBHn5kyBE8IjEH/form)

--- a/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
@@ -12,9 +12,10 @@ time=20
 name="Morning orientation"
 src="blocks/morning-orientation"
 time=20
-[[blocks]]
+[[blocks.nested.blocks]]
 name = "Disclaimer: this exercise is from Code Your Future"
 src = "blocks/disclaimer-mc"
+time = 0
 [[blocks]]
 name="Workshop"
 src="blocks/workshop"

--- a/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
@@ -4,7 +4,6 @@ layout = 'day-plan'
 emoji= '🧑🏾‍🤝‍🧑🏾'
 menu_level = ['sprint']
 weight = 3
-
 [[blocks]]
 name="Energiser"
 src="blocks/energiser"

--- a/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
@@ -15,7 +15,6 @@ time=20
 [[blocks]]
 name = "Disclaimer: this exercise is from Code Your Future"
 src = "blocks/disclaimer-mc"
-time = 0
 [[blocks]]
 name="Workshop"
 src="blocks/workshop"

--- a/org-cyf-itp/content/data-groups/sprints/2/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/2/day-plan/index.md
@@ -15,7 +15,6 @@ time=20
 [[blocks]]
 name = "Disclaimer: this exercise is from Code Your Future"
 src = "blocks/disclaimer-mc"
-time = 0
 [[blocks]]
 name="Workshop"
 src="blocks/workshop"

--- a/org-cyf-itp/content/data-groups/sprints/3/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/3/day-plan/index.md
@@ -15,7 +15,6 @@ time = 20
 [[blocks]]
 name = "Disclaimer: this exercise is from Code Your Future"
 src = "blocks/disclaimer-mc"
-time = 0
 [[blocks]]
 name="Workshop"
 src="blocks/workshop"

--- a/org-cyf-itp/content/data-groups/success/index.md
+++ b/org-cyf-itp/content/data-groups/success/index.md
@@ -45,4 +45,4 @@ However, please do not make any pull requests to the original Code Your Future r
 
 Any PRs you're submitting must have been reviewed, and must be labelled Complete by a volunteer.
 
-Submit the following items to complete this module on your private slack channel with the MigraCode team.
+Submit all the following items to complete this module through this [Submission Form](https://airtable.com/appHB49eVBBLG0KZH/pagHBHn5kyBE8IjEH/form)


### PR DESCRIPTION
## What does this change?
 This changes one disclaimer block to a nested one and adds the assignment submission links to the Success pages of both data groups and flows.

<!-- Add a description of what your PR changes here -->

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #issue-number

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module | Sprint | Page Type | Block Type

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
